### PR TITLE
Add mobile add-session page; return to origin

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
+import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from "react-router-dom";
 import { useState, useEffect } from "react";
 
 import { checkSession } from "./api/api";
@@ -9,7 +9,15 @@ import SkaterOverviewPage from "./pages/SkaterOverviewPage";
 import EquipmentPage from "./pages/EquipmentPage";
 import MaintenancePage from "./pages/MaintenancePage";
 import IceTimePage from "./pages/IceTimePage";
+import AddSessionPage from "./pages/AddSessionPage";
 
+function RequireAuth({ session, children }) {
+  const location = useLocation();
+  if (!session.logged_in) {
+    return <Navigate to="/login" state={{ from: location.pathname }} replace />;
+  }
+  return children;
+}
 
 function App() {
   const [session, setSession] = useState(null);
@@ -24,11 +32,12 @@ function App() {
     <Router>
       <Routes>
         <Route path="/login" element={<LoginPage onLogin={setSession} />} />
-        <Route path="/dashboard" element={session.logged_in ? <DashboardPage /> : <Navigate to="/login" />} />
-        <Route path="/skater_overview" element={session.logged_in ? <SkaterOverviewPage /> : <Navigate to="/login" />} />
-        <Route path="/equipment/configs" element={session.logged_in ? <EquipmentPage /> : <Navigate to="/login" />} />
-        <Route path="/equipment/maintenance" element={session.logged_in ? <MaintenancePage /> : <Navigate to="/login" />} />
-        <Route path="/ice_time" element={session.logged_in ? <IceTimePage /> : <Navigate to="/login" />} />
+        <Route path="/dashboard" element={<RequireAuth session={session}><DashboardPage /></RequireAuth>} />
+        <Route path="/skater_overview" element={<RequireAuth session={session}><SkaterOverviewPage /></RequireAuth>} />
+        <Route path="/equipment/configs" element={<RequireAuth session={session}><EquipmentPage /></RequireAuth>} />
+        <Route path="/equipment/maintenance" element={<RequireAuth session={session}><MaintenancePage /></RequireAuth>} />
+        <Route path="/ice_time" element={<RequireAuth session={session}><IceTimePage /></RequireAuth>} />
+        <Route path="/add-session" element={<RequireAuth session={session}><AddSessionPage /></RequireAuth>} />
         <Route path="*" element={<Navigate to={session.logged_in ? "/dashboard" : "/login"} />} />
       </Routes>
     </Router>

--- a/src/pages/AddSessionPage.css
+++ b/src/pages/AddSessionPage.css
@@ -1,0 +1,125 @@
+.add-session-page {
+  min-height: 100vh;
+  min-height: 100dvh;
+  background: linear-gradient(135deg, rgba(42, 27, 161, 0.85), rgba(29, 210, 177, 0.85) 100%);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 1rem;
+  padding-top: calc(env(safe-area-inset-top, 0px) + 1rem);
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 1rem);
+}
+
+.add-session-card {
+  width: 100%;
+  max-width: 480px;
+  background: #1e293b;
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
+}
+
+.add-session-header {
+  background: #22c55e;
+  padding: 1.25rem 1.5rem;
+}
+
+.add-session-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.add-session-form {
+  padding: 1.25rem 1.5rem 1.5rem;
+}
+
+.add-session-form .form-label {
+  color: #94a3b8;
+  font-weight: 500;
+  font-size: 0.875rem;
+  margin-bottom: 0.25rem;
+}
+
+.add-session-form .form-control,
+.add-session-form .form-select {
+  background: #0f172a;
+  border: 1px solid #334155;
+  color: #f1f5f9;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  padding: 0.75rem 1rem;
+  min-height: 48px;
+  transition: border-color 0.15s ease;
+}
+
+.add-session-form .form-control:focus,
+.add-session-form .form-select:focus {
+  border-color: #22c55e;
+  box-shadow: 0 0 0 0.2rem rgba(34, 197, 94, 0.2);
+  background: #0f172a;
+  color: #f1f5f9;
+}
+
+.add-session-form .form-control::placeholder {
+  color: #475569;
+}
+
+.add-session-submit {
+  font-weight: 700;
+  font-size: 1.125rem;
+  padding: 0.875rem;
+  border-radius: 0.75rem;
+  letter-spacing: 0.3px;
+}
+
+.add-session-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 4rem 1rem;
+  color: #94a3b8;
+  font-size: 1.1rem;
+}
+
+.add-session-success {
+  padding: 3rem 1.5rem 2rem;
+  text-align: center;
+  color: #f1f5f9;
+}
+
+.success-check {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: #22c55e;
+  color: #fff;
+  font-size: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 1.5rem;
+}
+
+.add-session-success h2 {
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.add-session-success p {
+  color: #94a3b8;
+  margin-bottom: 2rem;
+}
+
+.success-actions {
+  max-width: 280px;
+  margin: 0 auto;
+}
+
+/* Option text in dark selects */
+.add-session-form .form-select option {
+  background: #1e293b;
+  color: #f1f5f9;
+}

--- a/src/pages/AddSessionPage.js
+++ b/src/pages/AddSessionPage.js
@@ -1,0 +1,344 @@
+import React, { useState, useEffect, useRef } from "react";
+import { Form, Button, Spinner, Alert } from "react-bootstrap";
+import { Link, useNavigate } from "react-router-dom";
+import { getRinks, getSkaterOverview, getCoaches, getIceTypes, submitIceTime } from "../api/api";
+import dayjs from "dayjs";
+import "./AddSessionPage.css";
+
+const STORAGE_KEY = "skatetrax_add_session_draft";
+
+function saveDraft(fields) {
+  try { sessionStorage.setItem(STORAGE_KEY, JSON.stringify(fields)); } catch {}
+}
+
+function loadDraft() {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch { return null; }
+}
+
+function clearDraft() {
+  try { sessionStorage.removeItem(STORAGE_KEY); } catch {}
+}
+
+export default function AddSessionPage() {
+  const navigate = useNavigate();
+  const draft = useRef(loadDraft());
+
+  const [rinks, setRinks] = useState([]);
+  const [preferredRink, setPreferredRink] = useState("");
+  const [coaches, setCoaches] = useState([]);
+  const [preferredCoach, setPreferredCoach] = useState("");
+  const [coachRate, setCoachRate] = useState("");
+  const [iceTypes, setIceTypes] = useState([]);
+  const [selectedIceType, setSelectedIceType] = useState("");
+
+  const [date, setDate] = useState(draft.current?.date || dayjs().format("YYYY-MM-DD"));
+  const [iceTime, setIceTime] = useState(draft.current?.iceTime || "");
+  const [iceCost, setIceCost] = useState(draft.current?.iceCost || "");
+  const [coachMinutes, setCoachMinutes] = useState(draft.current?.coachMinutes || "");
+
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(null);
+  const [submitLoading, setSubmitLoading] = useState(false);
+  const [submitError, setSubmitError] = useState(null);
+  const [submitSuccess, setSubmitSuccess] = useState(false);
+  const [restoredDraft, setRestoredDraft] = useState(!!draft.current);
+  const submittingRef = useRef(false);
+
+  useEffect(() => {
+    async function loadFormData() {
+      setLoading(true);
+      setLoadError(null);
+      try {
+        const [userData, rinksData, coachesData, iceTypesData] = await Promise.all([
+          getSkaterOverview(),
+          getRinks(),
+          getCoaches(),
+          getIceTypes(),
+        ]);
+
+        const rinksList = Array.isArray(rinksData) ? rinksData : [];
+        setRinks(rinksList);
+
+        const coachesList = Array.isArray(coachesData) ? coachesData : [];
+        setCoaches(coachesList);
+
+        const typesList = Array.isArray(iceTypesData) ? iceTypesData : [];
+        setIceTypes(typesList);
+
+        const d = draft.current;
+        if (d) {
+          setPreferredRink(d.preferredRink || rinksList[0]?.rink_id || "");
+          setPreferredCoach(d.preferredCoach || "");
+          setCoachRate(d.coachRate || "");
+          setSelectedIceType(d.selectedIceType || typesList[0]?.ice_type_id || "");
+          clearDraft();
+        } else {
+          setPreferredRink(userData?.user_meta?.user_preferred_rink_id || rinksList[0]?.rink_id || "");
+          const coachId = userData?.user_meta?.user_primary_coach_id || "";
+          setPreferredCoach(coachId);
+          const foundCoach = coachesList.find(c => c.coach_id === coachId);
+          setCoachRate(foundCoach ? foundCoach.coach_rate : "");
+          setSelectedIceType(typesList[0]?.ice_type_id || "");
+        }
+      } catch (err) {
+        if (err.message && err.message.includes("401")) {
+          navigate("/login", { state: { from: "/add-session" }, replace: true });
+          return;
+        }
+        setLoadError(err.message || "Failed to load form data.");
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadFormData();
+  }, [navigate]);
+
+  const handleCoachChange = (e) => {
+    const id = e.target.value;
+    setPreferredCoach(id);
+    const found = coaches.find(c => c.coach_id === id);
+    setCoachRate(found ? found.coach_rate : "");
+  };
+
+  const resetForm = () => {
+    setDate(dayjs().format("YYYY-MM-DD"));
+    setIceTime("");
+    setIceCost("");
+    setCoachMinutes("");
+    setCoachRate("");
+    setSubmitSuccess(false);
+    setSubmitError(null);
+    setRestoredDraft(false);
+    clearDraft();
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (submittingRef.current) return;
+    submittingRef.current = true;
+    setSubmitLoading(true);
+    setSubmitError(null);
+    setSubmitSuccess(false);
+
+    const payload = {
+      date,
+      ice_time: Number(iceTime),
+      ice_cost: Number(iceCost),
+      coach_time: Number(coachMinutes),
+      coach_cost: Number(coachRate),
+      skate_type: selectedIceType,
+      rink_id: preferredRink,
+      coach_id: preferredCoach,
+    };
+
+    try {
+      await submitIceTime(payload);
+      clearDraft();
+      setSubmitSuccess(true);
+    } catch (err) {
+      if (err.message && err.message.includes("401")) {
+        saveDraft({ date, iceTime, iceCost, coachMinutes, coachRate, selectedIceType, preferredRink, preferredCoach });
+        navigate("/login", { state: { from: "/add-session" }, replace: true });
+        return;
+      }
+      setSubmitError(err.message || "Failed to submit session.");
+    } finally {
+      submittingRef.current = false;
+      setSubmitLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="add-session-page">
+        <div className="add-session-loading">
+          <Spinner animation="border" variant="success" />
+          <span>Loading...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="add-session-page">
+        <Alert variant="danger" className="m-3">{loadError}</Alert>
+        <div className="text-center">
+          <Button variant="outline-secondary" onClick={() => window.location.reload()}>
+            Retry
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (submitSuccess) {
+    return (
+      <div className="add-session-page">
+        <div className="add-session-card">
+          <div className="add-session-success">
+            <div className="success-check">&#10003;</div>
+            <h2>Session Added</h2>
+            <p>Your ice time has been recorded.</p>
+            <div className="success-actions">
+              <Button variant="success" size="lg" className="w-100 mb-2" onClick={resetForm}>
+                Add Another
+              </Button>
+              <Link to="/dashboard" className="btn btn-outline-secondary w-100">
+                Back to Dashboard
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="add-session-page">
+      <div className="add-session-card">
+        <div className="add-session-header">
+          <h1>Add Session</h1>
+        </div>
+
+        <Form onSubmit={handleSubmit} className="add-session-form">
+          {restoredDraft && (
+            <Alert variant="info" className="mb-3" dismissible onClose={() => setRestoredDraft(false)}>
+              Your previous entry was restored.
+            </Alert>
+          )}
+          <Form.Group className="mb-3">
+            <Form.Label>Date</Form.Label>
+            <Form.Control
+              type="date"
+              value={date}
+              onChange={e => setDate(e.target.value)}
+              className="form-control-lg"
+            />
+          </Form.Group>
+
+          <Form.Group className="mb-3">
+            <Form.Label>Ice Time (minutes)</Form.Label>
+            <Form.Control
+              type="number"
+              inputMode="numeric"
+              value={iceTime}
+              onChange={e => setIceTime(e.target.value)}
+              placeholder="0"
+              className="form-control-lg"
+            />
+          </Form.Group>
+
+          <Form.Group className="mb-3">
+            <Form.Label>Ice Cost ($)</Form.Label>
+            <Form.Control
+              type="number"
+              inputMode="decimal"
+              value={iceCost}
+              onChange={e => setIceCost(e.target.value)}
+              placeholder="0.00"
+              className="form-control-lg"
+            />
+          </Form.Group>
+
+          <Form.Group className="mb-3">
+            <Form.Label>Coach Time (minutes)</Form.Label>
+            <Form.Control
+              type="number"
+              inputMode="numeric"
+              value={coachMinutes}
+              onChange={e => setCoachMinutes(e.target.value)}
+              placeholder="0"
+              className="form-control-lg"
+            />
+          </Form.Group>
+
+          <Form.Group className="mb-3">
+            <Form.Label>Coach Cost ($)</Form.Label>
+            <Form.Control
+              type="number"
+              inputMode="decimal"
+              value={coachRate}
+              onChange={e => setCoachRate(e.target.value)}
+              placeholder="0.00"
+              className="form-control-lg"
+            />
+          </Form.Group>
+
+          <Form.Group className="mb-3">
+            <Form.Label>Skate Type</Form.Label>
+            <Form.Select
+              value={selectedIceType}
+              onChange={e => setSelectedIceType(e.target.value)}
+              className="form-select-lg"
+            >
+              {iceTypes.map(type => (
+                <option value={type.ice_type_id} key={type.ice_type_id}>
+                  {type.ice_type}
+                </option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+
+          <Form.Group className="mb-3">
+            <Form.Label>Rink</Form.Label>
+            <Form.Select
+              value={preferredRink}
+              onChange={e => setPreferredRink(e.target.value)}
+              className="form-select-lg"
+            >
+              {rinks.map(rink => (
+                <option value={rink.rink_id} key={rink.rink_id}>
+                  {rink.rink_name}
+                </option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+
+          <Form.Group className="mb-4">
+            <Form.Label>Coach</Form.Label>
+            <Form.Select
+              value={preferredCoach}
+              onChange={handleCoachChange}
+              className="form-select-lg"
+            >
+              {coaches.map(coach => (
+                <option value={coach.coach_id} key={coach.coach_id}>
+                  {coach.coach_Fname} {coach.coach_Lname}
+                </option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+
+          {submitError && (
+            <Alert variant="danger" className="mb-3">{submitError}</Alert>
+          )}
+
+          <Button
+            variant="success"
+            type="submit"
+            size="lg"
+            className="w-100 add-session-submit"
+            disabled={submitLoading}
+          >
+            {submitLoading ? (
+              <>
+                <Spinner animation="border" size="sm" className="me-2" />
+                Submitting...
+              </>
+            ) : (
+              "Add Session"
+            )}
+          </Button>
+
+          <Link to="/dashboard" className="btn btn-link w-100 mt-2 text-muted">
+            Cancel
+          </Link>
+        </Form>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { login, checkSession } from "../api/api";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 
 export default function LoginPage({ onLogin }) {
   const [aLogin, setALogin] = useState("");
@@ -8,6 +8,7 @@ export default function LoginPage({ onLogin }) {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -18,7 +19,8 @@ export default function LoginPage({ onLogin }) {
       if (resp.message === "Login successful") {
         const session = await checkSession();
         onLogin(session);
-        navigate("/dashboard");
+        const destination = location.state?.from || "/dashboard";
+        navigate(destination, { replace: true });
       } else {
         setError(resp.message || "Login failed");
       }


### PR DESCRIPTION
## Changes:

### New '/add-session' page
- still requires authentication
- for adding skate sessions via mobile device.
- Uses the same form data and existing API as the current desktop version's "Add Time" modal
- is CSS dressed for vertical mobile friendly usage. 

### Return To Origin
- successful login no longer forces user back to 'dashboard' page
- allows for a form draft state in case a session expires mid-form entry