### PR TITLE
update figure skater calendar to only show comps - not exhibitions, fix for broken/stale session -> now requests re-login

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,6 +1,10 @@
 const BASE_URL = import.meta.env.VITE_API_BASE_URL || `http://${window.location.hostname}:5000/api/v4`;
 
 async function handleResponse(resp) {
+  if (resp.status === 401) {
+    window.location.replace("/login");
+    throw new Error("Session expired");
+  }
   if (!resp.ok) {
     const text = await resp.text();
     throw new Error(`${resp.status} ${resp.statusText}: ${text.slice(0, 200)}`);
@@ -22,6 +26,7 @@ export async function checkSession() {
   const resp = await fetch(`${BASE_URL}/auth/session`, {
     credentials: "include"
   });
+  if (!resp.ok) return { logged_in: false };
   return resp.json();
 }
 
@@ -71,7 +76,7 @@ export async function getIceTime({ monthsBack = 0, window = 12 } = {}) {
   if (window !== 12) params.set("window", window);
   const qs = params.toString();
   const resp = await fetch(`${BASE_URL}/members/ice_time${qs ? `?${qs}` : ""}`, { credentials: "include" });
-  return resp.json();
+  return handleResponse(resp);
 }
 
 export async function submitIceTime(data) {

--- a/src/pages/IceTimePage.jsx
+++ b/src/pages/IceTimePage.jsx
@@ -557,7 +557,12 @@ export default function IceTimePage() {
                             ],
                           }}
                           options={{
-                            plugins: { legend: { labels: { color: '#a1a1aa' } } },
+                            plugins: {
+                              legend: { labels: { color: '#a1a1aa' } },
+                              tooltip: {
+                                filter: (item) => item.dataset.label !== 'Competitions',
+                              },
+                            },
                             elements: { line: { borderWidth: 2 }, point: { radius: 3 } },
                             scales: { x: { ticks: { color: '#a1a1aa' } }, y: { min: 0, ticks: { color: '#a1a1aa' } } },
                             responsive: true,


### PR DESCRIPTION
Figure skating calendar erroneously reported performances/exhibitions when should have only shown competitions

Fix an issue where login sessions become stale after app upgrades - now forces user to re-login to fix the stale or broken session